### PR TITLE
Remove redundant lines from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 
 .DS_Store
-basic/.DS_Store
-advanced/.DS_Store
 utilities/.ipynb_checkpoints/


### PR DESCRIPTION
`.DS_Store` includes occurrences in subdirectories